### PR TITLE
Refactor: extract MAX_TOKENS as a constant

### DIFF
--- a/lambda/handler.py
+++ b/lambda/handler.py
@@ -5,6 +5,7 @@ from botocore.exceptions import ClientError
 bedrock = boto3.client("bedrock-runtime", region_name="eu-north-1")
 
 MODEL_ID = "anthropic.claude-3-haiku-20240307-v1:0"
+MAX_TOKENS = 512
 
 
 def lambda_handler(event, context):
@@ -17,7 +18,7 @@ def lambda_handler(event, context):
 
         payload = {
             "anthropic_version": "bedrock-2023-05-31",
-            "max_tokens": 512,
+            "max_tokens": MAX_TOKENS,
             "messages": [
                 {"role": "user", "content": message}
             ]


### PR DESCRIPTION
Small refactor to extract the max_tokens value into a named constant for easier configuration.