### PR TITLE
fix: plain text only in email reports

### DIFF
--- a/.github/workflows/cloudwatch-investigation.yml
+++ b/.github/workflows/cloudwatch-investigation.yml
@@ -110,6 +110,7 @@ jobs:
           - Your assessment: is anything worth worrying about?
 
           Be direct and concise. 4-8 lines max.
+          Write in plain text only — no markdown, no asterisks, no bold, no bullet symbols.
 
           Metrics:
           {json.dumps(metrics, indent=2)}

--- a/.github/workflows/health-check.yml
+++ b/.github/workflows/health-check.yml
@@ -65,6 +65,7 @@ jobs:
                   "content": f"""You are a monitoring agent for a Bedrock Chat API.
           Analyze these health check results and write a brief status report (3-5 lines).
           Flag anything concerning. Be direct.
+          Write in plain text only — no markdown, no asterisks, no bold, no bullet symbols.
 
           Results:
           {summary}


### PR DESCRIPTION
Instruct the AI to write plain text with no markdown, asterisks or bold formatting in both the health check and CloudWatch investigation emails.